### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 description: >
-  F0cal Farm Orb simplifies interactions with the F0cal device farm allowing you to  run your builds on a variety of edge
-  compute  devices including the Raspberry Pi, Jetson Nano, and the Jetson TX1 and TX2 and many more.
+  F0cal Farm Orb simplifies interactions with the F0cal device farm allowing you to run your builds on a variety of edge
+  compute devices including the Raspberry Pi, Jetson Nano, and the Jetson TX1 and TX2 and many more.
 
-  To gain access to the F0cal device farm please visit https://www.f0cal.com
-
-  Orb source: https://github.com/f0cal/farm-orb
+display:
+  source_url: https://github.com/f0cal/farm-orb
+  home_url: https://www.f0cal.com
 
 
 


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.
